### PR TITLE
add support for serverless enterprise creds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "serverless-shell",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "engines": {
-    "node": ">=4.0"
+    "node": ">=6.0"
   },
   "description": "Serverless Shell with env vars Plugin",
   "author": "United Income <engineering@unitedincome.com>",


### PR DESCRIPTION
Serverless Dashboard can provide the AWS creds based on the a deploy profile and `app`/`org` in your `serverless.yml`: https://github.com/serverless/enterprise/blob/master/docs/aws-access-role.md

This sets those credentials, if present, to the relevant AWS env vars for use in your shell.

Also added some debug info when `SLS_DEBUG` env var is set.

I went ahead and bumped the version number too. But I don't think I have push access for this package on npm any more.