### PR TITLE
Fix deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,11 +34,13 @@ class ServerlessLocalShell {
               '"--function myFunction")',
             shortcut: 'f',
             required: false,
+            type: 'string',
           },
           shell: {
             usage: 'Specify a different shell (e.g. "--shell bash")',
             shortcut: 'S',
             required: false,
+            type: 'string',
           },
           quiet: {
             usage:
@@ -46,6 +48,7 @@ class ServerlessLocalShell {
             shortcut: 'q',
             required: false,
             default: false,
+            type: 'boolean',
           },
         },
       },


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - ServerlessLocalShell for "function", "shell", "quiet"
```

Fixes https://github.com/UnitedIncome/serverless-shell/issues/7.